### PR TITLE
feat: add photo and video gallery

### DIFF
--- a/src/app/Provider.jsx
+++ b/src/app/Provider.jsx
@@ -15,7 +15,9 @@ const Provider = ({ children }) => {
     blogPosts: [],
     teachingExperiences: [],
     awards: [],
-    collaborations: []
+    collaborations: [],
+    photos: [],
+    videos: []
   });
 
   const getUserData = async () => {

--- a/src/app/admin/components/FormContent.jsx
+++ b/src/app/admin/components/FormContent.jsx
@@ -5,6 +5,8 @@ import { useUser } from '../../Provider';
 import { BlogSection } from './addSections/blogs/blogSection';
 import { TeachingExperienceSection } from '@/app/admin/components/addSections/teachingExperiences/TeachingExperienceSection';
 import { StudentSection } from './addSections/students/studentSection';
+import { PhotoSection } from './addSections/photos/photoSection';
+import { VideoSection } from './addSections/videos/videoSection';
 // import ProjectSection from '@/app/admin/components/addSections/Project/ProjectSection';
 // import ResearchPaperSection from '@/app/admin/components/addSections/ResearchPapers/researchPaperSection';
 // import { ConferenceSection } from '@/app/admin/components/addSections/conferances/conferanceSection';
@@ -48,6 +50,10 @@ const FormContent = () => {
         <BlogSection />
         <div className="divider"></div>
         <StudentSection />
+        <div className="divider"></div>
+        <PhotoSection />
+        <div className="divider"></div>
+        <VideoSection />
         {/* <div className="divider"></div>
         <AchievementsSection /> */}
         {/* <div className="divider"></div>

--- a/src/app/admin/components/addSections/photos/addPhoto.jsx
+++ b/src/app/admin/components/addSections/photos/addPhoto.jsx
@@ -1,0 +1,184 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import { Camera } from 'lucide-react';
+import { toast } from 'react-hot-toast';
+import { uploadImage } from '@/utils/uploadImage';
+
+export const AddPhoto = ({ isOpen, onClose, editingPhoto, onPhotoAdded }) => {
+  const fileInputRef = useRef(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({
+    title: '',
+    caption: '',
+    order: '',
+    imageUrl: ''
+  });
+
+  useEffect(() => {
+    if (editingPhoto) {
+      setFormData({
+        title: editingPhoto.title || '',
+        caption: editingPhoto.caption || '',
+        order: editingPhoto.order || '',
+        imageUrl: editingPhoto.imageUrl || ''
+      });
+    } else {
+      setFormData({ title: '', caption: '', order: '', imageUrl: '' });
+    }
+  }, [editingPhoto]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleImageUpload = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setIsUploading(true);
+    try {
+      const result = await uploadImage(file, {
+        bucketName: 'profile-images',
+        folderPath: 'gallery/photos'
+      });
+      if (result.success) {
+        setFormData((prev) => ({ ...prev, imageUrl: result.url }));
+        toast.success('Image uploaded successfully!');
+      } else {
+        throw new Error(result.error);
+      }
+    } catch (error) {
+      console.error('Error uploading image:', error);
+      toast.error(error.message || 'Failed to upload image');
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!formData.imageUrl) {
+      toast.error('Image is required');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const endpoint = editingPhoto ? `/api/photos/${editingPhoto._id || editingPhoto.id}` : '/api/photos';
+      const method = editingPhoto ? 'PUT' : 'POST';
+      const res = await fetch(endpoint, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+      if (!res.ok) {
+        throw new Error(editingPhoto ? 'Failed to update photo' : 'Failed to create photo');
+      }
+      await res.json();
+      onPhotoAdded();
+      onClose();
+    } catch (error) {
+      console.error('Error saving photo:', error);
+      toast.error(error.message || 'Failed to save photo');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="card bg-base-300 shadow-lg max-w-2xl mt-5">
+      <div className="card-body p-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <h3 className="card-title text-base mb-2">{editingPhoto ? 'Edit Photo' : 'Add Photo'}</h3>
+
+          <div className="form-control w-full">
+            <label className="label py-1">
+              <span className="label-text text-sm">Image</span>
+            </label>
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handleImageUpload}
+              className="hidden"
+              accept="image/jpeg,image/png,image/webp"
+              disabled={isUploading}
+            />
+            <div
+              className="relative border-2 border-dashed border-accent/30 rounded-lg p-2 cursor-pointer hover:border-accent/50 transition-colors"
+              style={{ height: '160px' }}
+              onClick={() => fileInputRef.current?.click()}
+            >
+              {isUploading ? (
+                <div className="absolute inset-0 flex items-center justify-center">
+                  <span className="loading loading-spinner loading-sm"></span>
+                </div>
+              ) : formData.imageUrl ? (
+                <img src={formData.imageUrl} alt="Photo" className="w-full h-full object-cover rounded-lg" />
+              ) : (
+                <div className="absolute inset-0 flex flex-col items-center justify-center">
+                  <Camera className="w-6 h-6 opacity-40" />
+                  <span className="text-xs mt-2">Click to upload</span>
+                </div>
+              )}
+            </div>
+          </div>
+
+          <div className="form-control">
+            <label className="label py-1">
+              <span className="label-text text-sm">Title</span>
+            </label>
+            <input
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              className="input input-bordered"
+            />
+          </div>
+
+          <div className="form-control">
+            <label className="label py-1">
+              <span className="label-text text-sm">Caption</span>
+            </label>
+            <textarea
+              name="caption"
+              value={formData.caption}
+              onChange={handleChange}
+              className="textarea textarea-bordered"
+              rows={3}
+            ></textarea>
+          </div>
+
+          <div className="form-control">
+            <label className="label py-1">
+              <span className="label-text text-sm">Order</span>
+            </label>
+            <input
+              type="number"
+              name="order"
+              value={formData.order}
+              onChange={handleChange}
+              className="input input-bordered"
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <button type="button" className="btn btn-ghost mr-2" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={isSubmitting || isUploading}>
+              {isSubmitting ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddPhoto;
+

--- a/src/app/admin/components/addSections/photos/photoList.jsx
+++ b/src/app/admin/components/addSections/photos/photoList.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export const PhotoList = ({ photosList, onEdit, onDelete }) => {
+  if (!photosList || photosList.length === 0) {
+    return <p className="text-center py-8 text-base-content/60">No photos found</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Thumbnail</th>
+            <th>Title</th>
+            <th>Caption</th>
+            <th>Order</th>
+            <th>Created</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {photosList.map((photo) => (
+            <tr key={photo._id}>
+              <td>
+                <img src={photo.imageUrl} alt={photo.title || 'Photo'} className="w-16 h-16 object-cover rounded" />
+              </td>
+              <td>{photo.title || '-'}</td>
+              <td className="max-w-xs truncate">{photo.caption || '-'}</td>
+              <td>{photo.order ?? '-'}</td>
+              <td>{new Date(photo.createdAt).toLocaleDateString()}</td>
+              <td className="flex gap-2">
+                <button className="btn btn-xs" onClick={() => onEdit(photo)}>Edit</button>
+                <button className="btn btn-xs btn-error" onClick={() => onDelete(photo._id)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default PhotoList;
+

--- a/src/app/admin/components/addSections/photos/photoSection.jsx
+++ b/src/app/admin/components/addSections/photos/photoSection.jsx
@@ -1,0 +1,66 @@
+import { Images } from 'lucide-react';
+import React from 'react';
+import { usePhotos } from './usePhotos';
+import { AddPhoto } from './addPhoto';
+import { PhotoList } from './photoList';
+import { Toaster } from 'react-hot-toast';
+
+export const PhotoSection = () => {
+  const {
+    photosList,
+    isLoading,
+    error,
+    editingPhoto,
+    isAddModalOpen,
+    handleEditPhoto,
+    handleDeletePhoto,
+    handlePhotoAdded,
+    getPhotosList,
+    openAddModal,
+    closeAddModal,
+  } = usePhotos();
+
+  return (
+    <section>
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-semibold flex items-center gap-2">
+          <Images className="w-6 h-6" />
+          Photo Gallery
+        </h2>
+        <button className="btn btn-primary" onClick={openAddModal}>
+          Add Photo
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="text-center py-8">
+          <span className="loading loading-spinner loading-lg"></span>
+          <p className="mt-2 text-base-content/60">Loading photos...</p>
+        </div>
+      ) : error ? (
+        <div className="text-center py-8">
+          <p className="text-error">{error}</p>
+          <button onClick={getPhotosList} className="btn btn-link mt-2">
+            Try again
+          </button>
+        </div>
+      ) : (
+        <PhotoList photosList={photosList} onEdit={handleEditPhoto} onDelete={handleDeletePhoto} />
+      )}
+
+      {isAddModalOpen && (
+        <AddPhoto
+          isOpen={isAddModalOpen}
+          onClose={closeAddModal}
+          editingPhoto={editingPhoto}
+          onPhotoAdded={handlePhotoAdded}
+        />
+      )}
+
+      <Toaster position="bottom-right" />
+    </section>
+  );
+};
+
+export default PhotoSection;
+

--- a/src/app/admin/components/addSections/photos/usePhotos.jsx
+++ b/src/app/admin/components/addSections/photos/usePhotos.jsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+
+export const usePhotos = () => {
+  const [photosList, setPhotosList] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [editingPhoto, setEditingPhoto] = useState(null);
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+
+  const getPhotosList = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const res = await fetch('/api/photos');
+      if (!res.ok) throw new Error('Failed to fetch photos');
+      const data = await res.json();
+      setPhotosList(data);
+    } catch (err) {
+      console.error('Error fetching photos:', err);
+      setError('Failed to fetch photos');
+      toast.error('Failed to fetch photos');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    getPhotosList();
+  }, []);
+
+  const handleEditPhoto = (photo) => {
+    setEditingPhoto(photo);
+    setIsAddModalOpen(true);
+  };
+
+  const handleDeletePhoto = async (photoId) => {
+    try {
+      const res = await fetch(`/api/photos/${photoId}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete photo');
+      toast.success('Photo deleted successfully!');
+      getPhotosList();
+    } catch (err) {
+      console.error('Error deleting photo:', err);
+      toast.error('Failed to delete photo');
+    }
+  };
+
+  const handlePhotoAdded = () => {
+    getPhotosList();
+    setEditingPhoto(null);
+    setIsAddModalOpen(false);
+    toast.success('Photo saved successfully!');
+  };
+
+  const openAddModal = () => {
+    setEditingPhoto(null);
+    setIsAddModalOpen(true);
+  };
+
+  const closeAddModal = () => {
+    setIsAddModalOpen(false);
+    setEditingPhoto(null);
+  };
+
+  return {
+    photosList,
+    isLoading,
+    error,
+    editingPhoto,
+    isAddModalOpen,
+    handleEditPhoto,
+    handleDeletePhoto,
+    handlePhotoAdded,
+    getPhotosList,
+    openAddModal,
+    closeAddModal,
+  };
+};
+
+export default usePhotos;
+

--- a/src/app/admin/components/addSections/videos/addVideo.jsx
+++ b/src/app/admin/components/addSections/videos/addVideo.jsx
@@ -1,0 +1,182 @@
+'use client';
+
+import React, { useState, useEffect, useRef } from 'react';
+import { toast } from 'react-hot-toast';
+import { uploadMedia } from '@/utils/uploadMedia';
+
+export const AddVideo = ({ isOpen, onClose, editingVideo, onVideoAdded }) => {
+  const fileInputRef = useRef(null);
+  const [isUploading, setIsUploading] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [formData, setFormData] = useState({
+    title: '',
+    description: '',
+    order: '',
+    videoUrl: '',
+    youtubeUrl: ''
+  });
+
+  useEffect(() => {
+    if (editingVideo) {
+      setFormData({
+        title: editingVideo.title || '',
+        description: editingVideo.description || '',
+        order: editingVideo.order || '',
+        videoUrl: editingVideo.videoUrl || '',
+        youtubeUrl: editingVideo.youtubeUrl || ''
+      });
+    } else {
+      setFormData({ title: '', description: '', order: '', videoUrl: '', youtubeUrl: '' });
+    }
+  }, [editingVideo]);
+
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleVideoUpload = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+    setIsUploading(true);
+    try {
+      const result = await uploadMedia(file, {
+        bucketName: 'media',
+        folderPath: 'gallery/videos'
+      });
+      if (result.success) {
+        setFormData((prev) => ({ ...prev, videoUrl: result.url, youtubeUrl: '' }));
+        toast.success('Video uploaded successfully!');
+      } else {
+        throw new Error(result.error);
+      }
+    } catch (error) {
+      console.error('Error uploading video:', error);
+      toast.error(error.message || 'Failed to upload video');
+    } finally {
+      setIsUploading(false);
+      if (fileInputRef.current) fileInputRef.current.value = '';
+    }
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!formData.videoUrl && !formData.youtubeUrl) {
+      toast.error('Provide a video file or YouTube URL');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      const endpoint = editingVideo ? `/api/videos/${editingVideo._id || editingVideo.id}` : '/api/videos';
+      const method = editingVideo ? 'PUT' : 'POST';
+      const res = await fetch(endpoint, {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      });
+      if (!res.ok) {
+        throw new Error(editingVideo ? 'Failed to update video' : 'Failed to create video');
+      }
+      await res.json();
+      onVideoAdded();
+      onClose();
+    } catch (error) {
+      console.error('Error saving video:', error);
+      toast.error(error.message || 'Failed to save video');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="card bg-base-300 shadow-lg max-w-2xl mt-5">
+      <div className="card-body p-4">
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <h3 className="card-title text-base mb-2">{editingVideo ? 'Edit Video' : 'Add Video'}</h3>
+
+          <div className="form-control w-full">
+            <label className="label py-1">
+              <span className="label-text text-sm">Upload Video</span>
+            </label>
+            <input
+              type="file"
+              ref={fileInputRef}
+              onChange={handleVideoUpload}
+              className="file-input file-input-bordered w-full"
+              accept="video/*"
+              disabled={isUploading}
+            />
+            {isUploading && <span className="loading loading-spinner loading-sm mt-2"></span>}
+            {formData.videoUrl && (
+              <video src={formData.videoUrl} controls className="mt-2 rounded" />
+            )}
+          </div>
+
+          <div className="form-control">
+            <label className="label py-1">
+              <span className="label-text text-sm">or YouTube URL</span>
+            </label>
+            <input
+              name="youtubeUrl"
+              value={formData.youtubeUrl}
+              onChange={handleChange}
+              className="input input-bordered"
+            />
+          </div>
+
+          <div className="form-control">
+            <label className="label py-1">
+              <span className="label-text text-sm">Title</span>
+            </label>
+            <input
+              name="title"
+              value={formData.title}
+              onChange={handleChange}
+              className="input input-bordered"
+            />
+          </div>
+
+          <div className="form-control">
+            <label className="label py-1">
+              <span className="label-text text-sm">Description</span>
+            </label>
+            <textarea
+              name="description"
+              value={formData.description}
+              onChange={handleChange}
+              className="textarea textarea-bordered"
+              rows={3}
+            ></textarea>
+          </div>
+
+          <div className="form-control">
+            <label className="label py-1">
+              <span className="label-text text-sm">Order</span>
+            </label>
+            <input
+              type="number"
+              name="order"
+              value={formData.order}
+              onChange={handleChange}
+              className="input input-bordered"
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <button type="button" className="btn btn-ghost mr-2" onClick={onClose}>
+              Cancel
+            </button>
+            <button type="submit" className="btn btn-primary" disabled={isSubmitting || isUploading}>
+              {isSubmitting ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default AddVideo;
+

--- a/src/app/admin/components/addSections/videos/useVideos.jsx
+++ b/src/app/admin/components/addSections/videos/useVideos.jsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { toast } from 'react-hot-toast';
+
+export const useVideos = () => {
+  const [videosList, setVideosList] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [editingVideo, setEditingVideo] = useState(null);
+  const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+
+  const getVideosList = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const res = await fetch('/api/videos');
+      if (!res.ok) throw new Error('Failed to fetch videos');
+      const data = await res.json();
+      setVideosList(data);
+    } catch (err) {
+      console.error('Error fetching videos:', err);
+      setError('Failed to fetch videos');
+      toast.error('Failed to fetch videos');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    getVideosList();
+  }, []);
+
+  const handleEditVideo = (video) => {
+    setEditingVideo(video);
+    setIsAddModalOpen(true);
+  };
+
+  const handleDeleteVideo = async (videoId) => {
+    try {
+      const res = await fetch(`/api/videos/${videoId}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Failed to delete video');
+      toast.success('Video deleted successfully!');
+      getVideosList();
+    } catch (err) {
+      console.error('Error deleting video:', err);
+      toast.error('Failed to delete video');
+    }
+  };
+
+  const handleVideoAdded = () => {
+    getVideosList();
+    setEditingVideo(null);
+    setIsAddModalOpen(false);
+    toast.success('Video saved successfully!');
+  };
+
+  const openAddModal = () => {
+    setEditingVideo(null);
+    setIsAddModalOpen(true);
+  };
+
+  const closeAddModal = () => {
+    setIsAddModalOpen(false);
+    setEditingVideo(null);
+  };
+
+  return {
+    videosList,
+    isLoading,
+    error,
+    editingVideo,
+    isAddModalOpen,
+    handleEditVideo,
+    handleDeleteVideo,
+    handleVideoAdded,
+    getVideosList,
+    openAddModal,
+    closeAddModal,
+  };
+};
+
+export default useVideos;
+

--- a/src/app/admin/components/addSections/videos/videoList.jsx
+++ b/src/app/admin/components/addSections/videos/videoList.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+export const VideoList = ({ videosList, onEdit, onDelete }) => {
+  if (!videosList || videosList.length === 0) {
+    return <p className="text-center py-8 text-base-content/60">No videos found</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Preview</th>
+            <th>Title</th>
+            <th>Order</th>
+            <th>Created</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {videosList.map((video) => (
+            <tr key={video._id}>
+              <td className="w-32">
+                {video.youtubeUrl ? (
+                  <iframe
+                    src={video.youtubeUrl.replace('watch?v=', 'embed/')}
+                    className="w-32 h-20"
+                    allowFullScreen
+                  ></iframe>
+                ) : (
+                  <video src={video.videoUrl} className="w-32 h-20" />
+                )}
+              </td>
+              <td>{video.title || '-'}</td>
+              <td>{video.order ?? '-'}</td>
+              <td>{new Date(video.createdAt).toLocaleDateString()}</td>
+              <td className="flex gap-2">
+                <button className="btn btn-xs" onClick={() => onEdit(video)}>Edit</button>
+                <button className="btn btn-xs btn-error" onClick={() => onDelete(video._id)}>Delete</button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default VideoList;
+

--- a/src/app/admin/components/addSections/videos/videoSection.jsx
+++ b/src/app/admin/components/addSections/videos/videoSection.jsx
@@ -1,0 +1,66 @@
+import { Video as VideoIcon } from 'lucide-react';
+import React from 'react';
+import { useVideos } from './useVideos';
+import { AddVideo } from './addVideo';
+import { VideoList } from './videoList';
+import { Toaster } from 'react-hot-toast';
+
+export const VideoSection = () => {
+  const {
+    videosList,
+    isLoading,
+    error,
+    editingVideo,
+    isAddModalOpen,
+    handleEditVideo,
+    handleDeleteVideo,
+    handleVideoAdded,
+    getVideosList,
+    openAddModal,
+    closeAddModal,
+  } = useVideos();
+
+  return (
+    <section>
+      <div className="flex justify-between items-center mb-6">
+        <h2 className="text-2xl font-semibold flex items-center gap-2">
+          <VideoIcon className="w-6 h-6" />
+          Video Gallery
+        </h2>
+        <button className="btn btn-primary" onClick={openAddModal}>
+          Add Video
+        </button>
+      </div>
+
+      {isLoading ? (
+        <div className="text-center py-8">
+          <span className="loading loading-spinner loading-lg"></span>
+          <p className="mt-2 text-base-content/60">Loading videos...</p>
+        </div>
+      ) : error ? (
+        <div className="text-center py-8">
+          <p className="text-error">{error}</p>
+          <button onClick={getVideosList} className="btn btn-link mt-2">
+            Try again
+          </button>
+        </div>
+      ) : (
+        <VideoList videosList={videosList} onEdit={handleEditVideo} onDelete={handleDeleteVideo} />
+      )}
+
+      {isAddModalOpen && (
+        <AddVideo
+          isOpen={isAddModalOpen}
+          onClose={closeAddModal}
+          editingVideo={editingVideo}
+          onVideoAdded={handleVideoAdded}
+        />
+      )}
+
+      <Toaster position="bottom-right" />
+    </section>
+  );
+};
+
+export default VideoSection;
+

--- a/src/app/api/getAllData/route.js
+++ b/src/app/api/getAllData/route.js
@@ -5,7 +5,9 @@ import {
   Profile,
   BlogPost,
   TeachingExperience,
-  Student 
+  Student,
+  Photo,
+  Video
 } from '@/models/models';
 
 export async function GET() {
@@ -27,18 +29,22 @@ export async function GET() {
     }
 
     // Get all data without userId filtering since there's only one user
-    const [ blogPosts = [], teachingExperiences = [], students = [] ] =
+    const [ blogPosts = [], teachingExperiences = [], students = [], photos = [], videos = [] ] =
       await Promise.all([
         BlogPost.find({}).sort({ createdAt: -1 }).catch(() => []),
         TeachingExperience.find({}).sort({ startDate: -1 }).catch(() => []),
         Student.find({}).sort({ createdAt: -1 }).catch(() => []),
+        Photo.find({}).sort({ order: 1, createdAt: -1 }).catch(() => []),
+        Video.find({}).sort({ order: 1, createdAt: -1 }).catch(() => []),
       ]);
 
     const portfolioData = {
       user: profile,
       blogPosts,
       teachingExperiences,
-      students     
+      students,
+      photos,
+      videos
     };
 
     console.log(portfolioData);

--- a/src/app/api/photos/[id]/route.js
+++ b/src/app/api/photos/[id]/route.js
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/utils/db';
+import { Photo } from '@/models/models';
+import { ObjectId } from 'mongodb';
+
+export async function PUT(request, { params }) {
+  try {
+    await connectDB();
+    const { id } = await params;
+    const data = await request.json();
+    const updated = await Photo.findByIdAndUpdate(new ObjectId(id), data, { new: true });
+    if (!updated) {
+      return NextResponse.json({ error: 'Photo not found' }, { status: 404 });
+    }
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error('Error updating photo:', error);
+    return NextResponse.json({ error: 'Failed to update photo' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  try {
+    await connectDB();
+    const { id } = await params;
+    const deleted = await Photo.findByIdAndDelete(new ObjectId(id));
+    if (!deleted) {
+      return NextResponse.json({ error: 'Photo not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting photo:', error);
+    return NextResponse.json({ error: 'Failed to delete photo' }, { status: 500 });
+  }
+}
+

--- a/src/app/api/photos/route.js
+++ b/src/app/api/photos/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/utils/db';
+import { Photo } from '@/models/models';
+
+export async function GET() {
+  try {
+    await connectDB();
+    const photos = await Photo.find({}).sort({ order: 1, createdAt: -1 });
+    return NextResponse.json(photos);
+  } catch (error) {
+    console.error('Error fetching photos:', error);
+    return NextResponse.json({ error: 'Failed to fetch photos' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    await connectDB();
+    const data = await request.json();
+    const photo = new Photo(data);
+    await photo.save();
+    return NextResponse.json(photo, { status: 201 });
+  } catch (error) {
+    console.error('Error creating photo:', error);
+    return NextResponse.json({ error: 'Failed to create photo' }, { status: 500 });
+  }
+}
+

--- a/src/app/api/videos/[id]/route.js
+++ b/src/app/api/videos/[id]/route.js
@@ -1,0 +1,36 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/utils/db';
+import { Video } from '@/models/models';
+import { ObjectId } from 'mongodb';
+
+export async function PUT(request, { params }) {
+  try {
+    await connectDB();
+    const { id } = await params;
+    const data = await request.json();
+    const updated = await Video.findByIdAndUpdate(new ObjectId(id), data, { new: true });
+    if (!updated) {
+      return NextResponse.json({ error: 'Video not found' }, { status: 404 });
+    }
+    return NextResponse.json(updated);
+  } catch (error) {
+    console.error('Error updating video:', error);
+    return NextResponse.json({ error: 'Failed to update video' }, { status: 500 });
+  }
+}
+
+export async function DELETE(request, { params }) {
+  try {
+    await connectDB();
+    const { id } = await params;
+    const deleted = await Video.findByIdAndDelete(new ObjectId(id));
+    if (!deleted) {
+      return NextResponse.json({ error: 'Video not found' }, { status: 404 });
+    }
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Error deleting video:', error);
+    return NextResponse.json({ error: 'Failed to delete video' }, { status: 500 });
+  }
+}
+

--- a/src/app/api/videos/route.js
+++ b/src/app/api/videos/route.js
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server';
+import connectDB from '@/utils/db';
+import { Video } from '@/models/models';
+
+export async function GET() {
+  try {
+    await connectDB();
+    const videos = await Video.find({}).sort({ order: 1, createdAt: -1 });
+    return NextResponse.json(videos);
+  } catch (error) {
+    console.error('Error fetching videos:', error);
+    return NextResponse.json({ error: 'Failed to fetch videos' }, { status: 500 });
+  }
+}
+
+export async function POST(request) {
+  try {
+    await connectDB();
+    const data = await request.json();
+    const video = new Video(data);
+    await video.save();
+    return NextResponse.json(video, { status: 201 });
+  } catch (error) {
+    console.error('Error creating video:', error);
+    return NextResponse.json({ error: 'Failed to create video' }, { status: 500 });
+  }
+}
+

--- a/src/app/pages/Gallery/PhotoGallery/page.jsx
+++ b/src/app/pages/Gallery/PhotoGallery/page.jsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useState } from "react";
+import { X, ChevronLeft, ChevronRight } from "lucide-react";
+import { useUser } from "../../../Provider";
+
+const PhotoGalleryPage = () => {
+  const { userData } = useUser();
+  const photos = userData?.photos || [];
+  const [currentIndex, setCurrentIndex] = useState(null);
+
+  const openModal = (index) => setCurrentIndex(index);
+  const closeModal = () => setCurrentIndex(null);
+  const showPrev = (e) => {
+    e.stopPropagation();
+    setCurrentIndex((currentIndex + photos.length - 1) % photos.length);
+  };
+  const showNext = (e) => {
+    e.stopPropagation();
+    setCurrentIndex((currentIndex + 1) % photos.length);
+  };
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+        {photos.map((photo, index) => (
+          <div
+            key={photo._id || index}
+            className="cursor-pointer rounded-lg overflow-hidden shadow-md border border-gray-100"
+            onClick={() => openModal(index)}
+          >
+            <img
+              src={photo.imageUrl}
+              alt={photo.title || `Photo ${index + 1}`}
+              className="w-full h-full object-cover"
+              loading="lazy"
+            />
+          </div>
+        ))}
+      </div>
+
+      {currentIndex !== null && (
+        <div
+          className="fixed inset-0 bg-black/80 flex items-center justify-center z-50"
+          onClick={closeModal}
+        >
+          <button
+            onClick={showPrev}
+            className="absolute left-4 text-white p-2"
+          >
+            <ChevronLeft size={32} />
+          </button>
+          <img
+            src={photos[currentIndex].imageUrl}
+            alt={photos[currentIndex].title || ''}
+            className="max-h-[80vh] object-contain rounded"
+          />
+          <button
+            onClick={showNext}
+            className="absolute right-4 text-white p-2"
+          >
+            <ChevronRight size={32} />
+          </button>
+          <button
+            onClick={closeModal}
+            className="absolute top-4 right-4 text-white p-2"
+          >
+            <X size={28} />
+          </button>
+          <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white p-4 text-center">
+            {photos[currentIndex].caption}
+          </div>
+          <div className="absolute bottom-0 left-0 right-0 pb-20 flex justify-center overflow-x-auto gap-2">
+            {photos.map((p, idx) => (
+              <img
+                key={idx}
+                src={p.imageUrl}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setCurrentIndex(idx);
+                }}
+                className={`h-16 w-16 object-cover rounded cursor-pointer ${
+                  idx === currentIndex ? 'ring-2 ring-white' : ''
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default PhotoGalleryPage;
+

--- a/src/app/pages/Gallery/VideoGallery/page.jsx
+++ b/src/app/pages/Gallery/VideoGallery/page.jsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useState } from "react";
+import { useUser } from "../../../Provider";
+
+const VideoGalleryPage = () => {
+  const { userData } = useUser();
+  const videos = userData?.videos || [];
+  const [visible, setVisible] = useState(6);
+
+  const loadMore = () => setVisible((v) => v + 6);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {videos.slice(0, visible).map((video, index) => (
+          <div
+            key={video._id || index}
+            className="bg-white rounded-lg shadow-md border border-gray-100 overflow-hidden"
+          >
+            {video.youtubeUrl ? (
+              <div className="aspect-video">
+                <iframe
+                  src={video.youtubeUrl.replace('watch?v=', 'embed/')}
+                  className="w-full h-full"
+                  allowFullScreen
+                ></iframe>
+              </div>
+            ) : (
+              <video src={video.videoUrl} controls className="w-full h-full" />
+            )}
+            <div className="p-4">
+              <h3 className="text-lg font-semibold text-[#064A6E] mb-2">
+                {video.title}
+              </h3>
+              {video.description && (
+                <p className="text-sm text-gray-600 line-clamp-2">
+                  {video.description}
+                </p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {visible < videos.length && (
+        <div className="flex justify-center mt-6">
+          <button onClick={loadMore} className="btn btn-primary">
+            Load More
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VideoGalleryPage;
+

--- a/src/models/models.js
+++ b/src/models/models.js
@@ -53,6 +53,27 @@ const TeachingExperienceSchema = new mongoose.Schema({
 
 export const TeachingExperience = (mongoose.models && mongoose.models.TeachingExperience) || mongoose.model('TeachingExperience', TeachingExperienceSchema);
 
+// Photo Gallery Model
+const PhotoSchema = new mongoose.Schema({
+  title: { type: String, maxlength: 200 },
+  caption: { type: String },
+  order: { type: Number },
+  imageUrl: { type: String, required: true }
+}, { timestamps: true });
+
+export const Photo = (mongoose.models && mongoose.models.Photo) || mongoose.model('Photo', PhotoSchema);
+
+// Video Gallery Model
+const VideoSchema = new mongoose.Schema({
+  title: { type: String, maxlength: 200 },
+  description: { type: String },
+  order: { type: Number },
+  videoUrl: { type: String },
+  youtubeUrl: { type: String }
+}, { timestamps: true });
+
+export const Video = (mongoose.models && mongoose.models.Video) || mongoose.model('Video', VideoSchema);
+
 // Project Model
 // const ProjectSchema = new mongoose.Schema({
 //   userId: { type: mongoose.Schema.Types.ObjectId, ref: 'User', required: true },


### PR DESCRIPTION
## Summary
- add Photo and Video Mongoose models and API routes
- extend provider and data fetcher to include photos and videos
- implement admin sections for managing gallery items
- add public PhotoGallery with lightbox and VideoGallery with load more

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a21bbc288c832dbe1832bfb0345ddc