### PR TITLE
Align gallery pages with site design and purge R2 media

### DIFF
--- a/src/app/api/photos/[id]/route.js
+++ b/src/app/api/photos/[id]/route.js
@@ -27,6 +27,24 @@ export async function DELETE(request, { params }) {
     if (!deleted) {
       return NextResponse.json({ error: 'Photo not found' }, { status: 404 });
     }
+
+    if (deleted.imageUrl) {
+      try {
+        const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL || 'http://localhost:3000';
+        const res = await fetch(`${baseUrl}/api/cloudFlare/deleteImage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ imageUrl: deleted.imageUrl }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          console.warn('Cloudflare image deletion failed:', data.error);
+        }
+      } catch (err) {
+        console.error('Error calling Cloudflare deletion API:', err);
+      }
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error deleting photo:', error);

--- a/src/app/api/videos/[id]/route.js
+++ b/src/app/api/videos/[id]/route.js
@@ -27,6 +27,24 @@ export async function DELETE(request, { params }) {
     if (!deleted) {
       return NextResponse.json({ error: 'Video not found' }, { status: 404 });
     }
+
+    if (deleted.videoUrl) {
+      try {
+        const baseUrl = process.env.NEXT_PUBLIC_VERCEL_URL || 'http://localhost:3000';
+        const res = await fetch(`${baseUrl}/api/cloudFlare/deleteImage`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ imageUrl: deleted.videoUrl }),
+        });
+        const data = await res.json();
+        if (!data.success) {
+          console.warn('Cloudflare video deletion failed:', data.error);
+        }
+      } catch (err) {
+        console.error('Error calling Cloudflare deletion API:', err);
+      }
+    }
+
     return NextResponse.json({ success: true });
   } catch (error) {
     console.error('Error deleting video:', error);

--- a/src/app/pages/Gallery/PhotoGallery/page.jsx
+++ b/src/app/pages/Gallery/PhotoGallery/page.jsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
 import { X, ChevronLeft, ChevronRight } from "lucide-react";
 import { useUser } from "../../../Provider";
 
@@ -21,23 +22,47 @@ const PhotoGalleryPage = () => {
   };
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-        {photos.map((photo, index) => (
-          <div
-            key={photo._id || index}
-            className="cursor-pointer rounded-lg overflow-hidden shadow-md border border-gray-100"
-            onClick={() => openModal(index)}
-          >
-            <img
-              src={photo.imageUrl}
-              alt={photo.title || `Photo ${index + 1}`}
-              className="w-full h-full object-cover"
-              loading="lazy"
-            />
-          </div>
-        ))}
-      </div>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 text-[#223843]">
+      <main className="container mx-auto px-6 py-10 max-w-6xl">
+        {/* Breadcrumb */}
+        <nav className="flex items-center space-x-2 text-sm text-gray-600 mb-6">
+          <Link href="/" className="hover:text-[#0284C7] transition-colors">
+            Home
+          </Link>
+          <ChevronRight className="w-4 h-4" />
+          <span className="text-[#0284C7] font-medium">Photo Gallery</span>
+        </nav>
+
+        {/* Page Title */}
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold text-[#064A6E] mb-2">Photo Gallery</h1>
+          <div className="h-[3px] w-24 bg-[#0284C7] rounded-full"></div>
+          <p className="text-gray-600 mt-4">A glimpse into various moments and events.</p>
+        </div>
+
+        {/* Photo Grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+          {photos.map((photo, index) => (
+            <div
+              key={photo._id || index}
+              className="bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden cursor-pointer border border-gray-100"
+              onClick={() => openModal(index)}
+            >
+              <img
+                src={photo.imageUrl}
+                alt={photo.title || `Photo ${index + 1}`}
+                className="w-full h-48 object-cover"
+                loading="lazy"
+              />
+              {photo.caption && (
+                <div className="p-4">
+                  <p className="text-sm text-gray-600 line-clamp-2">{photo.caption}</p>
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </main>
 
       {currentIndex !== null && (
         <div
@@ -79,9 +104,7 @@ const PhotoGalleryPage = () => {
                   e.stopPropagation();
                   setCurrentIndex(idx);
                 }}
-                className={`h-16 w-16 object-cover rounded cursor-pointer ${
-                  idx === currentIndex ? 'ring-2 ring-white' : ''
-                }`}
+                className={`h-16 w-16 object-cover rounded cursor-pointer ${idx === currentIndex ? 'ring-2 ring-white' : ''}`}
               />
             ))}
           </div>

--- a/src/app/pages/Gallery/VideoGallery/page.jsx
+++ b/src/app/pages/Gallery/VideoGallery/page.jsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
 import { useUser } from "../../../Provider";
 
 const VideoGalleryPage = () => {
@@ -11,45 +13,64 @@ const VideoGalleryPage = () => {
   const loadMore = () => setVisible((v) => v + 6);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 p-6">
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {videos.slice(0, visible).map((video, index) => (
-          <div
-            key={video._id || index}
-            className="bg-white rounded-lg shadow-md border border-gray-100 overflow-hidden"
-          >
-            {video.youtubeUrl ? (
-              <div className="aspect-video">
-                <iframe
-                  src={video.youtubeUrl.replace('watch?v=', 'embed/')}
-                  className="w-full h-full"
-                  allowFullScreen
-                ></iframe>
-              </div>
-            ) : (
-              <video src={video.videoUrl} controls className="w-full h-full" />
-            )}
-            <div className="p-4">
-              <h3 className="text-lg font-semibold text-[#064A6E] mb-2">
-                {video.title}
-              </h3>
-              {video.description && (
-                <p className="text-sm text-gray-600 line-clamp-2">
-                  {video.description}
-                </p>
-              )}
-            </div>
-          </div>
-        ))}
-      </div>
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 text-[#223843]">
+      <main className="container mx-auto px-6 py-10 max-w-6xl">
+        {/* Breadcrumb */}
+        <nav className="flex items-center space-x-2 text-sm text-gray-600 mb-6">
+          <Link href="/" className="hover:text-[#0284C7] transition-colors">
+            Home
+          </Link>
+          <ChevronRight className="w-4 h-4" />
+          <span className="text-[#0284C7] font-medium">Video Gallery</span>
+        </nav>
 
-      {visible < videos.length && (
-        <div className="flex justify-center mt-6">
-          <button onClick={loadMore} className="btn btn-primary">
-            Load More
-          </button>
+        {/* Page Title */}
+        <div className="mb-8">
+          <h1 className="text-4xl font-bold text-[#064A6E] mb-2">Video Gallery</h1>
+          <div className="h-[3px] w-24 bg-[#0284C7] rounded-full"></div>
+          <p className="text-gray-600 mt-4">Collection of talks and lectures.</p>
         </div>
-      )}
+
+        {/* Video Grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {videos.slice(0, visible).map((video, index) => (
+            <div
+              key={video._id || index}
+              className="bg-white rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 overflow-hidden border border-gray-100"
+            >
+              <div className="aspect-video bg-black">
+                {video.youtubeUrl ? (
+                  <iframe
+                    src={video.youtubeUrl.replace('watch?v=', 'embed/')}
+                    className="w-full h-full"
+                    allowFullScreen
+                  ></iframe>
+                ) : (
+                  <video src={video.videoUrl} controls className="w-full h-full" />
+                )}
+              </div>
+              <div className="p-4">
+                <h3 className="text-lg font-semibold text-[#064A6E] mb-2">
+                  {video.title}
+                </h3>
+                {video.description && (
+                  <p className="text-sm text-gray-600 line-clamp-2">
+                    {video.description}
+                  </p>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {visible < videos.length && (
+          <div className="flex justify-center mt-6">
+            <button onClick={loadMore} className="btn btn-primary">
+              Load More
+            </button>
+          </div>
+        )}
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Revamp Photo and Video gallery pages to match the site's section layout with breadcrumbs, headings and card grids
- Ensure video titles and descriptions display by wrapping Cloudflare-hosted videos in an aspect-ratio container
- Remove photo and video files from Cloudflare R2 when deleted via admin API

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a239576264832db2f39114feed50a2