### PR TITLE
Enable bulk photo uploads and hide empty captions

### DIFF
--- a/src/app/admin/components/addSections/photos/photoList.jsx
+++ b/src/app/admin/components/addSections/photos/photoList.jsx
@@ -11,7 +11,6 @@ export const PhotoList = ({ photosList, onEdit, onDelete }) => {
         <thead>
           <tr>
             <th>Thumbnail</th>
-            <th>Title</th>
             <th>Caption</th>
             <th>Order</th>
             <th>Created</th>
@@ -22,9 +21,8 @@ export const PhotoList = ({ photosList, onEdit, onDelete }) => {
           {photosList.map((photo) => (
             <tr key={photo._id}>
               <td>
-                <img src={photo.imageUrl} alt={photo.title || 'Photo'} className="w-16 h-16 object-cover rounded" />
+                <img src={photo.imageUrl} alt={photo.caption || 'Photo'} className="w-16 h-16 object-cover rounded" />
               </td>
-              <td>{photo.title || '-'}</td>
               <td className="max-w-xs truncate">{photo.caption || '-'}</td>
               <td>{photo.order ?? '-'}</td>
               <td>{new Date(photo.createdAt).toLocaleDateString()}</td>

--- a/src/app/admin/components/addSections/photos/photoSection.jsx
+++ b/src/app/admin/components/addSections/photos/photoSection.jsx
@@ -28,7 +28,7 @@ export const PhotoSection = () => {
           Photo Gallery
         </h2>
         <button className="btn btn-primary" onClick={openAddModal}>
-          Add Photo
+          Add Photos
         </button>
       </div>
 

--- a/src/app/api/photos/route.js
+++ b/src/app/api/photos/route.js
@@ -17,12 +17,12 @@ export async function POST(request) {
   try {
     await connectDB();
     const data = await request.json();
-    const photo = new Photo(data);
-    await photo.save();
-    return NextResponse.json(photo, { status: 201 });
+    const photosData = Array.isArray(data) ? data : [data];
+    const photos = await Photo.insertMany(photosData);
+    return NextResponse.json(photos, { status: 201 });
   } catch (error) {
     console.error('Error creating photo:', error);
-    return NextResponse.json({ error: 'Failed to create photo' }, { status: 500 });
+    return NextResponse.json({ error: 'Failed to create photo(s)' }, { status: 500 });
   }
 }
 

--- a/src/app/pages/Gallery/PhotoGallery/page.jsx
+++ b/src/app/pages/Gallery/PhotoGallery/page.jsx
@@ -50,7 +50,7 @@ const PhotoGalleryPage = () => {
             >
               <img
                 src={photo.imageUrl}
-                alt={photo.title || `Photo ${index + 1}`}
+                alt={photo.caption || `Photo ${index + 1}`}
                 className="w-full h-48 object-cover"
                 loading="lazy"
               />
@@ -77,7 +77,7 @@ const PhotoGalleryPage = () => {
           </button>
           <img
             src={photos[currentIndex].imageUrl}
-            alt={photos[currentIndex].title || ''}
+            alt={photos[currentIndex].caption || ''}
             className="max-h-[80vh] object-contain rounded"
           />
           <button
@@ -92,9 +92,11 @@ const PhotoGalleryPage = () => {
           >
             <X size={28} />
           </button>
-          <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white p-4 text-center">
-            {photos[currentIndex].caption}
-          </div>
+          {photos[currentIndex].caption && (
+            <div className="absolute bottom-0 left-0 right-0 bg-black/60 text-white p-4 text-center">
+              {photos[currentIndex].caption}
+            </div>
+          )}
           <div className="absolute bottom-0 left-0 right-0 pb-20 flex justify-center overflow-x-auto gap-2">
             {photos.map((p, idx) => (
               <img

--- a/src/models/models.js
+++ b/src/models/models.js
@@ -55,7 +55,6 @@ export const TeachingExperience = (mongoose.models && mongoose.models.TeachingEx
 
 // Photo Gallery Model
 const PhotoSchema = new mongoose.Schema({
-  title: { type: String, maxlength: 200 },
   caption: { type: String },
   order: { type: Number },
   imageUrl: { type: String, required: true }


### PR DESCRIPTION
## Summary
- Allow bulk photo uploads with optional captions and display order
- Simplify photo model to caption, order, and image URL
- Hide caption area on gallery pages when no caption is provided

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23fafea68832d98b778c534a5267c