### PR TITLE
Refactor video gallery model and sort media by date

### DIFF
--- a/src/app/admin/components/addSections/videos/addVideo.jsx
+++ b/src/app/admin/components/addSections/videos/addVideo.jsx
@@ -9,8 +9,7 @@ export const AddVideo = ({ isOpen, onClose, editingVideo, onVideoAdded }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     title: '',
-    description: '',
-    order: '',
+    date: new Date().toISOString().split('T')[0],
     videoUrl: '',
     youtubeUrl: '',
     file: null,
@@ -57,8 +56,9 @@ export const AddVideo = ({ isOpen, onClose, editingVideo, onVideoAdded }) => {
     if (editingVideo) {
       setFormData({
         title: editingVideo.title || '',
-        description: editingVideo.description || '',
-        order: editingVideo.order || '',
+        date: editingVideo.date
+          ? new Date(editingVideo.date).toISOString().split('T')[0]
+          : new Date().toISOString().split('T')[0],
         videoUrl: editingVideo.videoUrl || '',
         youtubeUrl:
           toYouTubeEmbedUrl(editingVideo.youtubeUrl || '') ||
@@ -69,8 +69,7 @@ export const AddVideo = ({ isOpen, onClose, editingVideo, onVideoAdded }) => {
     } else {
       setFormData({
         title: '',
-        description: '',
-        order: '',
+        date: new Date().toISOString().split('T')[0],
         videoUrl: '',
         youtubeUrl: '',
         file: null,
@@ -137,8 +136,7 @@ export const AddVideo = ({ isOpen, onClose, editingVideo, onVideoAdded }) => {
 
       const payload = {
         title: formData.title?.trim(),
-        description: formData.description?.trim(),
-        order: formData.order ? Number(formData.order) : undefined,
+        date: formData.date,
         videoUrl: hasR2 ? videoUrl : '',
         youtubeUrl: hasYT ? ytEmbed : '',
       };
@@ -236,28 +234,14 @@ export const AddVideo = ({ isOpen, onClose, editingVideo, onVideoAdded }) => {
               className="input input-bordered"
             />
           </div>
-
           <div className="form-control">
             <label className="label py-1">
-              <span className="label-text text-sm">Description</span>
-            </label>
-            <textarea
-              name="description"
-              value={formData.description}
-              onChange={handleChange}
-              className="textarea textarea-bordered"
-              rows={3}
-            ></textarea>
-          </div>
-
-          <div className="form-control">
-            <label className="label py-1">
-              <span className="label-text text-sm">Order</span>
+              <span className="label-text text-sm">Date</span>
             </label>
             <input
-              type="number"
-              name="order"
-              value={formData.order}
+              type="date"
+              name="date"
+              value={formData.date}
               onChange={handleChange}
               className="input input-bordered"
             />

--- a/src/app/admin/components/addSections/videos/videoList.jsx
+++ b/src/app/admin/components/addSections/videos/videoList.jsx
@@ -12,8 +12,7 @@ export const VideoList = ({ videosList, onEdit, onDelete, deletingId }) => {
           <tr>
             <th>Preview</th>
             <th>Title</th>
-            <th>Order</th>
-            <th>Created</th>
+            <th>Date</th>
             <th>Actions</th>
           </tr>
         </thead>
@@ -32,8 +31,7 @@ export const VideoList = ({ videosList, onEdit, onDelete, deletingId }) => {
                 )}
               </td>
               <td>{video.title || '-'}</td>
-              <td>{video.order ?? '-'}</td>
-              <td>{new Date(video.createdAt).toLocaleDateString()}</td>
+              <td>{video.date ? new Date(video.date).toLocaleDateString() : '-'}</td>
               <td className="flex gap-2">
                 <button className="btn btn-xs" onClick={() => onEdit(video)}>Edit</button>
                 <button

--- a/src/app/api/getAllData/route.js
+++ b/src/app/api/getAllData/route.js
@@ -34,8 +34,8 @@ export async function GET() {
         BlogPost.find({}).sort({ createdAt: -1 }).catch(() => []),
         TeachingExperience.find({}).sort({ startDate: -1 }).catch(() => []),
         Student.find({}).sort({ createdAt: -1 }).catch(() => []),
-        Photo.find({}).sort({ order: 1, createdAt: -1 }).catch(() => []),
-        Video.find({}).sort({ order: 1, createdAt: -1 }).catch(() => []),
+        Photo.find({}).sort({ date: -1, createdAt: -1 }).catch(() => []),
+        Video.find({}).sort({ date: -1, createdAt: -1 }).catch(() => []),
       ]);
 
     const portfolioData = {

--- a/src/app/api/videos/route.js
+++ b/src/app/api/videos/route.js
@@ -5,7 +5,7 @@ import { Video } from '@/models/models';
 export async function GET() {
   try {
     await connectDB();
-    const videos = await Video.find({}).sort({ order: 1, createdAt: -1 });
+    const videos = await Video.find({}).sort({ date: -1, createdAt: -1 });
     return NextResponse.json(videos);
   } catch (error) {
     console.error('Error fetching videos:', error);

--- a/src/app/pages/Gallery/PhotoGallery/page.jsx
+++ b/src/app/pages/Gallery/PhotoGallery/page.jsx
@@ -7,7 +7,9 @@ import { useUser } from "../../../Provider";
 
 const PhotoGalleryPage = () => {
   const { userData } = useUser();
-  const photos = userData?.photos || [];
+  const photos = [...(userData?.photos || [])].sort(
+    (a, b) => new Date(b.date || 0) - new Date(a.date || 0)
+  );
   const [currentIndex, setCurrentIndex] = useState(null);
 
   const openModal = (index) => setCurrentIndex(index);
@@ -54,11 +56,6 @@ const PhotoGalleryPage = () => {
                 className="w-full h-48 object-cover"
                 loading="lazy"
               />
-              {photo.caption && (
-                <div className="p-4">
-                  <p className="text-sm text-gray-600 line-clamp-2">{photo.caption}</p>
-                </div>
-              )}
             </div>
           ))}
         </div>

--- a/src/app/pages/Gallery/VideoGallery/page.jsx
+++ b/src/app/pages/Gallery/VideoGallery/page.jsx
@@ -7,7 +7,9 @@ import { useUser } from "../../../Provider";
 
 const VideoGalleryPage = () => {
   const { userData } = useUser();
-  const videos = userData?.videos || [];
+  const videos = [...(userData?.videos || [])].sort(
+    (a, b) => new Date(b.date || 0) - new Date(a.date || 0)
+  );
   const [visible, setVisible] = useState(6);
 
   const loadMore = () => setVisible((v) => v + 6);
@@ -53,11 +55,6 @@ const VideoGalleryPage = () => {
                 <h3 className="text-lg font-semibold text-[#064A6E] mb-2">
                   {video.title}
                 </h3>
-                {video.description && (
-                  <p className="text-sm text-gray-600 line-clamp-2">
-                    {video.description}
-                  </p>
-                )}
               </div>
             </div>
           ))}

--- a/src/models/models.js
+++ b/src/models/models.js
@@ -65,8 +65,7 @@ export const Photo = (mongoose.models && mongoose.models.Photo) || mongoose.mode
 // Video Gallery Model
 const VideoSchema = new mongoose.Schema({
   title: { type: String, maxlength: 200 },
-  description: { type: String },
-  order: { type: Number },
+  date: { type: Date, default: Date.now },
   videoUrl: { type: String },
   youtubeUrl: { type: String }
 }, { timestamps: true });


### PR DESCRIPTION
## Summary
- streamline video schema to keep only title and date (default current date)
- order photos and videos by most recent date in galleries
- hide photo captions until the image modal is opened

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(warnings: attempted import errors in CURRENTLY_NOT_IN_USE modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a2d6e5c5b0832d891c6b7910c69071